### PR TITLE
Update Socket to 1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/BlueSocket.git",
         "state": {
           "branch": null,
-          "revision": "f33e2d3e6da0b5b286073e7091eefd0ca56ebc63",
-          "version": "0.12.78"
+          "revision": "c46a3d41f5b2401d18bcb46d0101cdc5cd13e307",
+          "version": "1.0.52"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/IBM-Swift/BlueSocket.git", from: "0.12.78")
+    .package(url: "https://github.com/IBM-Swift/BlueSocket.git", from: "1.0.0")
   ],
   targets: [
     .target(

--- a/SwordRPC.podspec
+++ b/SwordRPC.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   }
 
   s.source_files = 'Sources/SwordRPC/*.swift', 'Sources/SwordRPC/Types/*.swift'
-  s.dependency 'BlueSocket', '~> 0.12'
+  s.dependency 'BlueSocket', '~> 1.0'
 end


### PR DESCRIPTION
I notarized an application using SwordRPC, and was continuously able to reproduce crashes upon socket initialization. While I have no good explanation why, I assume it must be something related to the enforced sandbox. Upgrading BlueSocket to 1.0 solved the issue entirely.